### PR TITLE
GFX thread sleep fix and Thread names

### DIFF
--- a/chip/ps4_videodrv.pas
+++ b/chip/ps4_videodrv.pas
@@ -431,6 +431,8 @@ begin
 
  sys_crt_init;
 
+ SetThreadDebugName(GetCurrentThreadId, 'GFX Thread');
+
  repeat
   work_do:=False;
 
@@ -450,7 +452,7 @@ begin
     //end;
    end else
    begin
-    time:=-100000;
+    time:=-50000;
     NtDelayExecution(True,@time);
     Continue;
    end;

--- a/kernel/ps4_event_flag.pas
+++ b/kernel/ps4_event_flag.pas
@@ -259,7 +259,7 @@ function ps4_sceKernelCreateEventFlag(
   attr,init:QWORD;
   pOptParam:PSceKernelEventFlagOptParam):Integer; SysV_ABI_CDecl;
 begin
- Writeln('sceKernelCreateEventFlag:',pName);
+ Writeln(SysLogPrefix, 'sceKernelCreateEventFlag:',pName);
 
  if (pOptParam<>nil) then
  begin
@@ -588,7 +588,7 @@ begin
  Result:=ef_enter(ef);
  if (Result<>0) then Exit;
 
- //Writeln('sceKernelClearEventFlag:',HexStr(ef),':',ef^.name,':',HexStr(bitPattern,16),':',ThreadID);
+ //Writeln(SysLogPrefix, 'sceKernelClearEventFlag:',HexStr(ef),':',ef^.name,':',HexStr(bitPattern,16),':',ThreadID);
 
  spin_lock(ef^.lock_list);
   fetch_and(ef^.bitPattern,bitPattern);

--- a/kernel/ps4_kernel_file.pas
+++ b/kernel/ps4_kernel_file.pas
@@ -93,7 +93,7 @@ begin
  Result:=0;
  if (path=nil) then Exit(-EINVAL);
 
- Writeln('open:',path,' ',flags,' (',OctStr(mode,3),')');
+ Writeln(SysLogPrefix, 'open:',path,' ',flags,' (',OctStr(mode,3),')');
 
  if ((flags and WR_RDWR)=WR_RDWR) then
  begin

--- a/kernel/ps4_libkernel.pas
+++ b/kernel/ps4_libkernel.pas
@@ -863,7 +863,7 @@ begin
  if (Word(id)=0) then Exit(SCE_SYSMODULE_ERROR_INVALID_VALUE);
  if ((Word(id)=$80) and (SDK_VERSION>=$3000000)) then Exit(SCE_SYSMODULE_ERROR_INVALID_VALUE);
 
- Writeln('sceSysmoduleLoadModule:',GetSysmoduleName(id));
+ Writeln(SysLogPrefix, 'sceSysmoduleLoadModule:',GetSysmoduleName(id));
  Result:=0;
 end;
 
@@ -871,7 +871,7 @@ function ps4_sceSysmoduleUnloadModule(id:DWord):Integer; SysV_ABI_CDecl;
 begin
  if (Word(id)=0) then Exit(SCE_SYSMODULE_ERROR_INVALID_VALUE);
 
- Writeln('sceSysmoduleUnloadModule:',GetSysmoduleName(id));
+ Writeln(SysLogPrefix, 'sceSysmoduleUnloadModule:',GetSysmoduleName(id));
  Result:=0;
 end;
 
@@ -879,7 +879,7 @@ function ps4_sceSysmoduleIsLoaded(id:DWord):Integer; SysV_ABI_CDecl;
 begin
  if (Word(id)=0) then Exit(SCE_SYSMODULE_ERROR_INVALID_VALUE);
 
- Writeln('sceSysmoduleIsLoaded:',GetSysmoduleName(id));
+ Writeln(SysLogPrefix, 'sceSysmoduleIsLoaded:',GetSysmoduleName(id));
  Result:=0; //0 -> loaded ; SCE_SYSMODULE_ERROR_UNLOADED -> not loaded
 end;
 
@@ -889,7 +889,7 @@ function ps4_sceSysmoduleIsLoadedInternal(id:DWord):Integer; SysV_ABI_CDecl;
 begin
  if ((id or $80000000)=$80000000) then Exit(SCE_SYSMODULE_ERROR_INVALID_VALUE);
 
- Writeln('sceSysmoduleIsLoadedInternal:',GetSysmoduleInternalName(id));
+ Writeln(SysLogPrefix, 'sceSysmoduleIsLoadedInternal:',GetSysmoduleInternalName(id));
  Result:=0; //0 -> loaded ; SCE_SYSMODULE_ERROR_UNLOADED -> not loaded
 end;
 
@@ -898,7 +898,7 @@ begin
  if ((id or $80000000)=$80000000) then Exit(SCE_SYSMODULE_ERROR_INVALID_VALUE);
  if ((Word(id)=$80) and (SDK_VERSION>=$3000000)) then Exit(SCE_SYSMODULE_ERROR_INVALID_VALUE);
 
- Writeln('sceSysmoduleLoadModuleInternal:',GetSysmoduleInternalName(id));
+ Writeln(SysLogPrefix, 'sceSysmoduleLoadModuleInternal:',GetSysmoduleInternalName(id));
  Result:=0;
 end;
 
@@ -911,7 +911,7 @@ begin
  if ((id or $80000000)=$80000000) or (flags<>0) then Exit(SCE_SYSMODULE_ERROR_INVALID_VALUE);
  if ((Word(id)=$80) and (SDK_VERSION>=$3000000)) then Exit(SCE_SYSMODULE_ERROR_INVALID_VALUE);
 
- Writeln('sceSysmoduleLoadModuleInternalWithArg:',GetSysmoduleInternalName(id));
+ Writeln(SysLogPrefix, 'sceSysmoduleLoadModuleInternalWithArg:',GetSysmoduleInternalName(id));
  if (pRes<>nil) then pRes^:=0;
  Result:=0;
 end;

--- a/kernel/ps4_pthread.pas
+++ b/kernel/ps4_pthread.pas
@@ -143,7 +143,7 @@ end;
 
 function ps4_scePthreadAttrInit(pAttr:p_pthread_attr_t):Integer; SysV_ABI_CDecl;
 begin
- Writeln('scePthreadAttrInit');
+ Writeln(SysLogPrefix, 'scePthreadAttrInit');
  if (pAttr=nil) then Exit(SCE_KERNEL_ERROR_EINVAL);
  pAttr^:=SwAllocMem(SizeOf(tthread_attr_t));
  if (pAttr^=nil) then Exit(SCE_KERNEL_ERROR_ENOMEM);
@@ -153,7 +153,7 @@ end;
 
 function ps4_scePthreadAttrDestroy(pAttr:p_pthread_attr_t):Integer; SysV_ABI_CDecl;
 begin
- Writeln('scePthreadAttrDestroy');
+ Writeln(SysLogPrefix, 'scePthreadAttrDestroy');
  Result:=SCE_KERNEL_ERROR_EINVAL;
  if (pAttr=nil) then Exit;
  SwFreeMem(XCHG(pAttr^,nil));
@@ -162,7 +162,7 @@ end;
 
 function ps4_pthread_attr_init(pAttr:p_pthread_attr_t):Integer; SysV_ABI_CDecl;
 begin
- Writeln('pthread_attr_init');
+ Writeln(SysLogPrefix, 'pthread_attr_init');
  if (pAttr=nil) then Exit(EINVAL);
  pAttr^:=SwAllocMem(SizeOf(tthread_attr_t));
  if (pAttr^=nil) then Exit(ENOMEM);
@@ -171,8 +171,8 @@ begin
 end;
 
 function ps4_pthread_attr_destroy(pAttr:p_pthread_attr_t):Integer; SysV_ABI_CDecl;
-begin
- Writeln('pthread_attr_destroy');
+begin                    
+ Writeln(SysLogPrefix, 'pthread_attr_destroy');
  Result:=EINVAL;
  if (pAttr=nil) then Exit;
  SwFreeMem(XCHG(pAttr^,nil));
@@ -469,8 +469,9 @@ begin
    data^.Attr.stacksize_attr:=StackLength;
   //end;
 
-  writeln('BeginThread:',data^.name,':',HexStr(data^.entry));
   tcb_thread:=data;
+  SetThreadDebugName(data^.ThreadId,'ps4:'+data^.name);
+  WriteLn(SysLogPrefix, 'BeginThread:',HexStr(data^.entry));
   _thread_init;
 
   wait_until_equal(data^.handle,0);
@@ -489,7 +490,7 @@ begin
   ReadWriteBarrier;
 
   _thread_cleanup;
-  writeln('EndThread:',data^.name);
+  writeln(SysLogPrefix,'EndThread:',data^.name);
 
   if CAS(data^.detachstate,PTHREAD_CREATE_DETACHED,_PREPARE_FREE) then
   begin
@@ -519,7 +520,7 @@ Var
  ss:SizeUInt;
  creationFlags:dword;
 begin
- Writeln('pthread_create:',HexStr(entry),' ',name);
+ Writeln(SysLogPrefix, 'pthread_create:',HexStr(entry),' ',name);
 
  Result:=EINVAL;
  if (pthread=nil) then Exit;
@@ -635,7 +636,7 @@ end;
 function ps4_scePthreadJoin(_pthread:pthread;value:PPointer):Integer; SysV_ABI_CDecl;
 begin
  if (_pthread=nil) then Exit(SCE_KERNEL_ERROR_EINVAL);
- Writeln('scePthreadJoin:',_pthread^.name);
+ Writeln(SysLogPrefix, 'scePthreadJoin:',_pthread^.name);
 
  if CAS(_pthread^.detachstate,PTHREAD_CREATE_JOINABLE,_PREPARE_FREE) then
  begin
@@ -705,7 +706,7 @@ var
 begin
  data:=tcb_thread;
  if (data=nil) then Exit;
- Writeln('ExitThread:',data^.name);
+ Writeln(SysLogPrefix, 'ExitThread');
  data^.arg:=value_ptr;
 
  ReadWriteBarrier;

--- a/src/ps4_libscehttp.pas
+++ b/src/ps4_libscehttp.pas
@@ -11,15 +11,20 @@ uses
 
 implementation
 
+uses sys_kernel;
+
+const
+ SCE_HTTP_NB_EVENT_SOCK_ERR = 8;
+
 function ps4_sceHttpInit(libnetMemId,libsslCtxId:Integer;poolSize:size_t):Integer; SysV_ABI_CDecl;
 begin
- Writeln('sceHttpInit:',poolSize);
- Result:=4;
+ Writeln(SysLogPrefix,'sceHttpInit poolSize=',poolSize);
+ Result:=4; // libhttpCtxId
 end;
 
 function ps4_sceHttpTerm(libhttpCtxId:Integer):Integer; SysV_ABI_CDecl;
 begin
- Writeln('sceHttpTerm:',libhttpCtxId);
+ Writeln(SysLogPrefix,'sceHttpTerm:',libhttpCtxId);
  Result:=0;
 end;
 
@@ -29,8 +34,8 @@ function ps4_sceHttpCreateTemplate(
 	  httpVer:Integer;
 	  autoProxyConf:Integer):Integer; SysV_ABI_CDecl;
 begin
- Writeln('userAgent:',userAgent);
- Result:=1;
+ Writeln(SysLogPrefix,'sceHttpCreateTemplate userAgent=',userAgent,' httpVer=',httpVer);
+ Result:=1; // templateId
 end;
 
 function ps4_sceHttpDeleteTemplate(templateId:Integer):Integer; SysV_ABI_CDecl;
@@ -60,13 +65,13 @@ end;
 
 function ps4_sceHttpSetEpoll(id:Integer;eh:SceHttpEpollHandle;userArg:Pointer):Integer; SysV_ABI_CDecl;
 begin
- Writeln('sceHttpSetEpoll');
+ Writeln(SysLogPrefix, 'sceHttpSetEpoll');
  Result:=0;
 end;
 
 function ps4_sceHttpUnsetEpoll(id:Integer):Integer; SysV_ABI_CDecl;
 begin
- Writeln('sceHttpUnsetEpoll');
+ Writeln(SysLogPrefix, 'sceHttpUnsetEpoll');
  Result:=0;
 end;
 
@@ -84,8 +89,9 @@ function ps4_sceHttpWaitRequest(eh:SceHttpEpollHandle;
                                 maxevents:Integer;
                                 timeout_us:Integer):Integer; SysV_ABI_CDecl;
 begin
- Writeln('sceHttpWaitReques');
- nbev^.events:=8; //SCE_HTTP_NB_EVENT_SOCK_ERR
+ WriteLn(SysLogPrefix, 'sceHttpWaitRequest handle=', HexStr(eh),' event.id=', nbev^.id,' maxevents=',maxevents);
+
+ nbev^.events:=SCE_HTTP_NB_EVENT_SOCK_ERR;
  nbev^.id:=3;
 
  Result:=1;
@@ -94,7 +100,7 @@ end;
 function ps4_sceHttpAddRequestHeader(id:Integer;name:PChar;value:PChar;mode:Integer):Integer; SysV_ABI_CDecl;
 begin
  Result:=0;
- Writeln(name,': ',value);
+ WriteLn(SysLogPrefix, 'sceHttpAddRequestHeader ',name,'=',value,' mode=',mode);
 end;
 
 type
@@ -106,7 +112,8 @@ type
                    userArg:Pointer):Integer; SysV_ABI_CDecl;
 
 function ps4_sceHttpsSetSslCallback(id:Integer;cbfunc:SceHttpsCallback;userArg:Pointer):Integer; SysV_ABI_CDecl;
-begin
+begin      
+ WriteLn(SysLogPrefix, 'sceHttpsSetSslCallback id=',id,' callback=',HexStr(@cbfunc));
  Result:=0;
 end;
 
@@ -114,7 +121,7 @@ function ps4_sceHttpCreateConnectionWithURL(tmplId:Integer;
                                             url:PChar;
                                             enableKeepalive:Boolean):Integer; SysV_ABI_CDecl;
 begin
- Writeln('sceHttpCreateConnectionWithURL:',url);
+ WriteLn(SysLogPrefix, 'sceHttpCreateConnectionWithURL:' + url);
  Result:=2;
 end;
 
@@ -128,13 +135,13 @@ function ps4_sceHttpCreateRequestWithURL2(connId:Integer;
                                           url:PChar;
                                           contentLength:QWORD):Integer; SysV_ABI_CDecl;
 begin
- Writeln('sceHttpCreateRequestWithURL2:',url);
+ WriteLn(SysLogPrefix, 'sceHttpCreateRequestWithURL2 method=', method, 'url=',url);
  Result:=3;
 end;
 
 function ps4_sceHttpDeleteRequest(reqId:Integer):Integer; SysV_ABI_CDecl;
 begin
- Writeln('sceHttpDeleteRequest');
+ WriteLn(SysLogPrefix, 'sceHttpDeleteRequest');
  Result:=0;
 end;
 
@@ -142,7 +149,7 @@ function ps4_sceHttpSendRequest(reqId:Integer;
                                 postData:Pointer;
                                 size:QWORD):Integer; SysV_ABI_CDecl;
 begin
- Writeln('sceHttpSendRequest');
+ WriteLn(SysLogPrefix, 'sceHttpSendRequest reqId=',reqId,' postData=',HexStr(postData));
  Result:=0;
 end;
 
@@ -219,7 +226,7 @@ function ps4_sceHttp2Init(libnetMemId,libsslCtxId:Integer;
                           poolSize:size_t;
                           maxConcurrentRequest:Integer):Integer; SysV_ABI_CDecl;
 begin
- Writeln('sceHttp2Init:',poolSize);
+ WriteLn(SysLogPrefix, 'sceHttp2Init poolSize=',poolSize);
  Result:=3;
 end;
 

--- a/src/ps4_libscenet.pas
+++ b/src/ps4_libscenet.pas
@@ -75,7 +75,7 @@ end;
 function ps4_sceNetPoolCreate(name:PChar;size,flags:Integer):Integer; SysV_ABI_CDecl;
 begin
  Writeln('sceNetPoolCreate:',name,':',size,':',flags);
- Result:=2;
+ Result:=2; // iNetLibId
 end;
 
 function ps4_sceNetPoolDestroy(memid:Integer):Integer; SysV_ABI_CDecl;

--- a/src/ps4_libscepad.pas
+++ b/src/ps4_libscepad.pas
@@ -17,7 +17,7 @@ uses
 implementation
 
 uses
- ps4_libSceVideoOut, uMappableInputs;
+ ps4_libSceVideoOut, uMappableInputs, sys_kernel;
 
 const
  SCE_PAD_ERROR_INVALID_ARG             =-2137915391; // 0x80920001
@@ -285,7 +285,7 @@ function ps4_scePadInit():Integer; SysV_ABI_CDecl;
 var
  controllerIndex:Integer;
 begin
- Writeln('scePadInit');
+ Writeln(SysLogPrefix,'scePadInit');
 
  // init xinput
  for controllerIndex := 0 to XUSER_MAX_COUNT - 1 do

--- a/src/ps4_libscevideoout.pas
+++ b/src/ps4_libscevideoout.pas
@@ -341,6 +341,8 @@ begin
  Timer.OnTimer:=@TUserApp(Application).OnTimer;
  Timer.Enabled:=true;
 
+ SetThreadDebugName(GetCurrentThreadId, 'FPPS4 App Run');
+
  Application.OnException:=nil;
  Application.CaptureExceptions:=False;
  Application.AddOnIdleHandler(@TUserApp(Application).OnIdleUpdate,False);

--- a/sys/sys_kernel.pas
+++ b/sys/sys_kernel.pas
@@ -113,13 +113,26 @@ function  GetProcessIoCounters(hProcess:HANDLE;
                                lpIoCounters:PIO_COUNTERS
                               ):BOOL; external 'kernel32';
 
+function SysLogPrefix : string;
+
 implementation
+
 
 uses
  ntapi,
  sys_pthread,
  sys_signal,
  sys_time;
+
+function SysLogPrefix : string;
+begin      
+ // Add thread name and id as prefix to log messages
+ Result := '';
+ if _get_curthread <> nil then
+ begin
+  Result:='['+_get_curthread^.name + ':'+ IntToStr(_get_curthread^.ThreadId) + '] ';
+ end;
+end;
 
 function px2sce(e:Integer):Integer;
 begin


### PR DESCRIPTION
This attempts to solve an issue experienced on my system: Sonic mania would cap at 43 fps while both GPU and CPU were idling. I set the sleep time to 1/2 of the previous value for NtDelayExecution in the GFX thread and it appears to have resolved the issue.

I thought this had to do with the maximum timer resolution of Windows, but I saw that this is already handled in ps4_time.pas initialization. Maybe NtDelayExecution is not influenced by NtSetTimerResolution or this is not the issue at all.

Comparison:

NtDelayExecution(...,-100000)
![image](https://user-images.githubusercontent.com/121519052/210187209-9585859a-cf85-4ee2-9786-eb0430ef46be.png)

NtDelayExecution(..., -50000)
![image](https://user-images.githubusercontent.com/121519052/210187158-642a9c0c-2e53-4b17-9808-7e71216681e3.png)


I also added thread names for debugging and in logs while investigating, so I figured this might be something worth sharing. I also stubbed out two functions:
sceGnmMapComputeQueue
sceGnmDingDong
