### PR TITLE
Separate PR and Main builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,6 @@ on:
       - '*'
     tags:        
       - '*'
-  pull_request:
-    branches:
-      - '*'
 
   workflow_dispatch:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,5 @@
 
-name: CI
+name: Main CI
 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: self-hosted
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Hash
         shell: cmd
@@ -39,7 +39,7 @@ jobs:
           strip fpPS4.exe
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         with:
           name: fpPS4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: self-hosted
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
 
       - name: Hash
         shell: cmd
@@ -36,7 +36,7 @@ jobs:
           strip fpPS4.exe
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
         with:
           name: fpPS4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: self-hosted
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v2
 
       - name: Hash
         shell: cmd
@@ -27,7 +27,7 @@ jobs:
           strip fpPS4.exe
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v2
         with:
           name: fpPS4
           path: fpPS4.exe

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,34 @@
+
+name: PR CI
+
+on:
+  push:
+    pull_request:
+      branches:
+        - '*'
+
+jobs:
+  build_windows:
+    runs-on: self-hosted
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Hash
+        shell: cmd
+        working-directory: ./
+        run: echo '%GITHUB_SHA:~0,7%' > tag.inc
+
+      - name: Compile
+        shell: cmd
+        working-directory: ./
+        run: |
+          lazbuild -B fpPS4.lpi > nul
+          strip fpPS4.exe
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: fpPS4
+          path: fpPS4.exe
+          if-no-files-found: warn


### PR DESCRIPTION
I separated Main builds and PR builds due to how Github handles these situations. If you have 1 YML for all builds, it'll only  build 1 at a time, inefficient. But, if you have two YMLs, one for PRs and one for Main commits, you can build a PR and a Main build at the same time! A weird multi-threading basically.