### PR TITLE
DISABLE_FMV_HACK, Boolean -> LongBool on relevant sceAvPlayerXxx functions

### DIFF
--- a/fpPS4.lpr
+++ b/fpPS4.lpr
@@ -85,6 +85,7 @@ begin
   Writeln('     IMAGE_TEST_HACK      //always mark that the texture has changed');
   Writeln('     IMAGE_LOAD_HACK      //never reload texture');
   Writeln('     DISABLE_SRGB_HACK    //disables hacked display of SRGB');
+  Writeln('     DISABLE_FMV_HACK     //disable in-game movies');
 
   Exit(False);
  end;
@@ -130,6 +131,7 @@ begin
            'IMAGE_TEST_HACK'     :vImageManager.IMAGE_TEST_HACK:=True;
            'IMAGE_LOAD_HACK'     :vImageManager.IMAGE_LOAD_HACK:=True;
            'DISABLE_SRGB_HACK'   :vFlip.SRGB_HACK:=False;
+           'DISABLE_FMV_HACK'    :ps4_libsceavplayer.DISABLE_FMV_HACK:=True;
            else;
           end;
          end;

--- a/src/ps4_libsceavplayer.pas
+++ b/src/ps4_libsceavplayer.pas
@@ -24,7 +24,7 @@ uses
   Math;
 
 var
-  DISABLE_FMV_HACK: Boolean = False;
+  DISABLE_FMV_HACK:Boolean=False;
 
 implementation
 
@@ -760,7 +760,7 @@ begin
  _sig_unlock;
 end;
 
-function ps4_sceAvPlayerIsActive(handle:SceAvPlayerHandle): Boolean; SysV_ABI_CDecl;
+function ps4_sceAvPlayerIsActive(handle:SceAvPlayerHandle): LongBool; SysV_ABI_CDecl;
 begin
  if DISABLE_FMV_HACK then
   Exit(False);
@@ -770,7 +770,7 @@ begin
  Exit(True);
 end;
 
-function ps4_sceAvPlayerSetLooping(handle:SceAvPlayerHandle;loopFlag:Boolean):DWord; SysV_ABI_CDecl;
+function ps4_sceAvPlayerSetLooping(handle:SceAvPlayerHandle;loopFlag:LongBool):DWord; SysV_ABI_CDecl;
 begin
  if DISABLE_FMV_HACK then
   Exit(0);
@@ -779,7 +779,7 @@ begin
  handle^.isLooped:=loopFlag;
 end;
 
-function _sceAvPlayerGetAudioData(handle:SceAvPlayerHandle;frameInfo:PSceAvPlayerFrameInfo):Boolean;
+function _sceAvPlayerGetAudioData(handle:SceAvPlayerHandle;frameInfo:PSceAvPlayerFrameInfo):LongBool;
 var
  audioData:TMemChunk;
 begin
@@ -807,14 +807,14 @@ begin
  end;
 end;
 
-function ps4_sceAvPlayerGetAudioData(handle:SceAvPlayerHandle;frameInfo:PSceAvPlayerFrameInfo):Boolean; SysV_ABI_CDecl;
+function ps4_sceAvPlayerGetAudioData(handle:SceAvPlayerHandle;frameInfo:PSceAvPlayerFrameInfo):LongBool; SysV_ABI_CDecl;
 begin
  _sig_lock;
  Result:=_sceAvPlayerGetAudioData(handle,frameInfo);
  _sig_unlock;
 end;
 
-function _sceAvPlayerGetVideoDataEx(handle:SceAvPlayerHandle;frameInfo:PSceAvPlayerFrameInfoEx):Boolean;
+function _sceAvPlayerGetVideoDataEx(handle:SceAvPlayerHandle;frameInfo:PSceAvPlayerFrameInfoEx):LongBool;
 var
  videoData:TMemChunk;
 begin
@@ -848,14 +848,14 @@ begin
  end;
 end;
 
-function ps4_sceAvPlayerGetVideoDataEx(handle:SceAvPlayerHandle;frameInfo:PSceAvPlayerFrameInfoEx):Boolean; SysV_ABI_CDecl;
+function ps4_sceAvPlayerGetVideoDataEx(handle:SceAvPlayerHandle;frameInfo:PSceAvPlayerFrameInfoEx):LongBool; SysV_ABI_CDecl;
 begin
  _sig_lock;
  Result:=_sceAvPlayerGetVideoDataEx(handle,frameInfo);
  _sig_unlock;
 end;
 
-function ps4_sceAvPlayerGetVideoData(handle:SceAvPlayerHandle;frameInfo:PSceAvPlayerFrameInfo):Boolean; SysV_ABI_CDecl;
+function ps4_sceAvPlayerGetVideoData(handle:SceAvPlayerHandle;frameInfo:PSceAvPlayerFrameInfo):LongBool; SysV_ABI_CDecl;
 begin
  Writeln(SysLogPrefix,'sceAvPlayerGetVideoData');
  // TODO: Rely on ps4_sceAvPlayerGetVideoDataEx to get the frame
@@ -874,8 +874,6 @@ end;
 
 function _sceAvPlayerStop(handle:SceAvPlayerHandle):Integer;
 begin
- if DISABLE_FMV_HACK then
-  Exit(-1);
  Result:=-1;
  if (handle=nil) then Exit;
 
@@ -894,8 +892,6 @@ end;
 
 function _sceAvPlayerClose(handle:SceAvPlayerHandle):Integer;
 begin
- if DISABLE_FMV_HACK then
-  Exit(-1);
  Result:=-1;
  if (handle=nil) then Exit;
 

--- a/src/ps4_libsceavplayer.pas
+++ b/src/ps4_libsceavplayer.pas
@@ -764,7 +764,7 @@ function ps4_sceAvPlayerIsActive(handle:SceAvPlayerHandle): LongBool; SysV_ABI_C
 begin
  if DISABLE_FMV_HACK then
   Exit(False);
- Writeln(SysLogPrefix,'sceAvPlayerIsActive');
+ //Writeln(SysLogPrefix,'sceAvPlayerIsActive');
  if (handle=nil) or (not handle^.playerState.IsPlaying) then
   Exit(False);
  Exit(True);
@@ -785,7 +785,7 @@ var
 begin
  if DISABLE_FMV_HACK then
   Exit(False);
- Writeln(SysLogPrefix,'sceAvPlayerGetAudioData');
+ //Writeln(SysLogPrefix,'sceAvPlayerGetAudioData');
  Result:=False;
  if (frameInfo<>nil) and (handle<>nil) and (handle^.playerState.IsPlaying) and (not handle^.isPaused) then
  begin
@@ -820,7 +820,7 @@ var
 begin
  if DISABLE_FMV_HACK then
   Exit(False);
- Writeln(SysLogPrefix,'sceAvPlayerGetVideoDataEx');
+ //Writeln(SysLogPrefix,'sceAvPlayerGetVideoDataEx');
  Result:=False;
  if (frameInfo<>nil) and (handle<>nil) and (handle^.playerState.IsPlaying) then
  begin

--- a/src/ps4_libsceavplayer.pas
+++ b/src/ps4_libsceavplayer.pas
@@ -23,6 +23,9 @@ uses
   Generics.Collections,
   Math;
 
+var
+  DISABLE_FMV_HACK: Boolean = False;
+
 implementation
 
 uses
@@ -665,6 +668,8 @@ var
  f              :THandle;
  source         :RawByteString;
 begin
+ if DISABLE_FMV_HACK then
+  Exit(-1);
  spin_lock(lock);
  // With file functions provided by client
  if (handle<>nil) and (handle^.fileReplacement.open<>nil) and (handle^.fileReplacement.close<>nil)
@@ -757,7 +762,9 @@ end;
 
 function ps4_sceAvPlayerIsActive(handle:SceAvPlayerHandle): Boolean; SysV_ABI_CDecl;
 begin
- //Writeln(SysLogPrefix,'sceAvPlayerIsActive');
+ if DISABLE_FMV_HACK then
+  Exit(False);
+ Writeln(SysLogPrefix,'sceAvPlayerIsActive');
  if (handle=nil) or (not handle^.playerState.IsPlaying) then
   Exit(False);
  Exit(True);
@@ -765,6 +772,8 @@ end;
 
 function ps4_sceAvPlayerSetLooping(handle:SceAvPlayerHandle;loopFlag:Boolean):DWord; SysV_ABI_CDecl;
 begin
+ if DISABLE_FMV_HACK then
+  Exit(0);
  Writeln(SysLogPrefix,'sceAvPlayerSetLooping');
  Result:=0;
  handle^.isLooped:=loopFlag;
@@ -774,7 +783,9 @@ function _sceAvPlayerGetAudioData(handle:SceAvPlayerHandle;frameInfo:PSceAvPlaye
 var
  audioData:TMemChunk;
 begin
- //Writeln(SysLogPrefix,'sceAvPlayerGetAudioData');
+ if DISABLE_FMV_HACK then
+  Exit(False);
+ Writeln(SysLogPrefix,'sceAvPlayerGetAudioData');
  Result:=False;
  if (frameInfo<>nil) and (handle<>nil) and (handle^.playerState.IsPlaying) and (not handle^.isPaused) then
  begin
@@ -807,7 +818,9 @@ function _sceAvPlayerGetVideoDataEx(handle:SceAvPlayerHandle;frameInfo:PSceAvPla
 var
  videoData:TMemChunk;
 begin
- //Writeln(SysLogPrefix,'sceAvPlayerGetVideoDataEx');
+ if DISABLE_FMV_HACK then
+  Exit(False);
+ Writeln(SysLogPrefix,'sceAvPlayerGetVideoDataEx');
  Result:=False;
  if (frameInfo<>nil) and (handle<>nil) and (handle^.playerState.IsPlaying) then
  begin
@@ -851,6 +864,8 @@ end;
 
 function ps4_sceAvPlayerCurrentTime(handle:SceAvPlayerHandle):QWord; SysV_ABI_CDecl;
 begin
+ if DISABLE_FMV_HACK then
+  Exit(0);
  if (handle=nil) or (not handle^.playerState.IsPlaying) then
   Result:=0
  else
@@ -859,6 +874,8 @@ end;
 
 function _sceAvPlayerStop(handle:SceAvPlayerHandle):Integer;
 begin
+ if DISABLE_FMV_HACK then
+  Exit(-1);
  Result:=-1;
  if (handle=nil) then Exit;
 
@@ -877,6 +894,8 @@ end;
 
 function _sceAvPlayerClose(handle:SceAvPlayerHandle):Integer;
 begin
+ if DISABLE_FMV_HACK then
+  Exit(-1);
  Result:=-1;
  if (handle=nil) then Exit;
 


### PR DESCRIPTION
- `DISABLE_FMV_HACK`, allows to disable in-game movies. AvPlayer will still be initialized, but it wont load any movie files.
- Boolean -> LongBool, this theoretically should fix a few games that boot into black screen after fmv, likely due to infinite loop caused by `sceAvPlayerIsActive` returns wrong value. I haven't test this myself tho because `wine` refuse to boot relevant games on my Linux laptop.