### PR TITLE
sceRemoteplaySetProhibition

### DIFF
--- a/src/ps4_libsceremoteplay.pas
+++ b/src/ps4_libsceremoteplay.pas
@@ -25,6 +25,11 @@ begin
  Result:=0;
 end;
 
+function ps4_sceRemoteplaySetProhibition:Integer; SysV_ABI_CDecl;
+begin
+ Result:=0;
+end;
+
 const
  SCE_REMOTEPLAY_CONNECTION_STATUS_DISCONNECT=0;
  SCE_REMOTEPLAY_CONNECTION_STATUS_CONNECT   =1;
@@ -49,6 +54,7 @@ begin
  lib^.set_proc($9354B082431238CF,@ps4_sceRemoteplayInitialize);
  lib^.set_proc($C50788AF24D7EDD6,@ps4_sceRemoteplayApprove);
  lib^.set_proc($8373CD8D8296AA74,@ps4_sceRemoteplayGetConnectionStatus);
+ lib^.set_proc($45FD1731547BC4FC,@ps4_sceRemoteplaySetProhibition);
 end;
 
 initialization


### PR DESCRIPTION
some games try to prevent remote play
netflix is an example for this, probably other streaming apps as well such as crunchyroll or amazon prime video