### PR TITLE
ps4_videodrv.pas

### DIFF
--- a/chip/ps4_videodrv.pas
+++ b/chip/ps4_videodrv.pas
@@ -445,6 +445,7 @@ begin
   m_nExpCur:=m_nExpCur*2;
  end;
  time:=-m_nExpCur;
+ time:=80;
  NtDelayExecution(True,@time);
 end;
 
@@ -458,6 +459,8 @@ Var
  time:Int64;
 begin
  time:=Int64(NT_INFINITE);
+ time:=80;
+ time:=-40;
  NtDelayExecution(True,@time);
 end;
 


### PR DESCRIPTION
I modified time changes to try optimizing the code, this may or may not improve performance on other games.
Heres three games that showed improvements:
The First Tree (before):
avg 14 FPS:
![The First Tree before](https://github.com/red-prig/fpPS4/assets/125112932/aa4c9ccf-d3fd-41d0-bc4a-ebb60378a220)

The First Tree (after):
avg 22 FPS:
![The First Tree after](https://github.com/red-prig/fpPS4/assets/125112932/50b38e4e-2c0b-4544-94d4-ce71961cf79f)

Tiny Troopers (before):
avg 19 FPS:
![Tiny Troopers before](https://github.com/red-prig/fpPS4/assets/125112932/cbec2a0d-5bcb-47f0-b9e7-7b9eadf6fbec)

Tiny Troopers (after):
avg 20 FPS:
![Tiny Troopers after](https://github.com/red-prig/fpPS4/assets/125112932/f33733f9-716d-4c69-81d5-8a4258aac085)

Super Toy Cars (before):
avg 18 FPS:
![Super Toy Cars before](https://github.com/red-prig/fpPS4/assets/125112932/cd9224d4-7ddf-47c2-8e3d-1ffbe53968eb)

Super Toy Cars (after):
avg 22 FPS:
![Super Toy Cars after](https://github.com/red-prig/fpPS4/assets/125112932/09445016-7162-4873-b54a-1fec506f4128)
